### PR TITLE
Add keyboard support

### DIFF
--- a/vlc-delete.lua
+++ b/vlc-delete.lua
@@ -21,7 +21,7 @@ function descriptor()
 		version = "0.1";
 		author = "surrim";
 		url = "https://github.com/surrim/vlc-delete/";
-		shortdesc = "Remove current file from playlist and disk";
+		shortdesc = "&Remove current file from playlist and disk";
 		description = [[
 <h1>vlc-delete</h1>"
 When you're playing a file, use VLC Delete to


### PR DESCRIPTION
Using access key notation "&(menu text)" allows for keyboard support (E.g., Alt + i + r).