### PR TITLE
Rename `hdd` to `disk`

### DIFF
--- a/vlc-delete.lua
+++ b/vlc-delete.lua
@@ -57,7 +57,7 @@ function windows_delete(file, trys, pause)
 	return nil, "Unable to delete file"
 end
 
-function remove_from_playlist_and_hdd()
+function remove_from_playlist_and_disk()
 	local id = vlc.playlist.current()
 	vlc.playlist.next()
 	sleep(1)
@@ -105,11 +105,11 @@ function activate()
 		end
 
 		if retval ~= nil then
-			remove_from_playlist_and_hdd()
+			remove_from_playlist_and_disk()
 		end
 	else
 		vlc.msg.info("[vlc-delete] removing: " .. uri)
-		remove_from_playlist_and_hdd() -- remove first so the file isn't locked by VLC
+		remove_from_playlist_and_disk() -- remove first so the file isn't locked by VLC
 		retval, err = windows_delete(uri, 3, 1)
 	end
 


### PR DESCRIPTION
As *HDD* probably stands for [Hard Disk Drive](https://en.wikipedia.org/wiki/Hard_disk_drive) but nowadays most computers use [SSD](https://en.wikipedia.org/wiki/Solid-state_drive).

Note that modifying *harddisk* in [the repository `About`](https://github.com/surrim/vlc-delete) would make sense.

![image](https://github.com/surrim/vlc-delete/assets/12752145/4b1940de-0ced-4b06-a887-70906cd9f6b2)
