### PR TITLE
vlc-delete.lua: fixed command_exist issue on Linux/macOS

### DIFF
--- a/vlc-delete.lua
+++ b/vlc-delete.lua
@@ -71,7 +71,11 @@ end
 
 function command_exists(command)
 	retval, err = os.execute(command)
-	return retval ~= nil
+	if retval == 32512  or retval == 127 then
+    	return false
+ 	else
+		return retval ~= nil
+	end
 end
 
 function current_uri_and_os()


### PR DESCRIPTION
On Linux/macOS command_exists will return true even is a command is not found. 
Since trash-put is tried first and If trash-put is not installed, the delete quietly fail.

This change will check if OS return is code 127 (file not found) or shifted by 8 bits by Lua (32512) which should cover the file not found issue.

PS. Probably 127 as far as I can tell isn't necessary, but due to the lack of firm documentation on the topic I'll err on the side of caution.

